### PR TITLE
Add a register hook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "register.js"
   ],
   "keywords": [
     "promise",

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ $ npm install --save loud-rejection
 const loudRejection = require('loud-rejection');
 const promiseFn = require('promise-fn');
 
+// Install the unhandledRejection listeners
 loudRejection();
 
 promiseFn();
@@ -38,6 +39,15 @@ function error(err) {
 promiseFn().catch(error);
 ```
 
+### Register Script
+
+As an alternative to requiring and invoking a function as described above, you may simply require 
+ `loud-rejection/register`. It automatically installs the unhandledRejection listeners for you.
+ This is handy for ES2015 style imports:
+
+```js
+import 'loud-rejection/register';
+```
 
 ## License
 

--- a/register.js
+++ b/register.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('./')();


### PR DESCRIPTION
~~I added a read-only property `loudRejection.installed`, used by the register script to avoid calling the function if it is already registered. I'm having second thoughts about that now.~~

~~We are telling people they should only be installing it as a top level tool (`cli.js`, etc). So protecting them from that warning seems antithetical to that.~~

@sindresorhus @LinusU - What do you think?

Closes #6 

@callumlocke