### PR TITLE
Refactoring Array#reduce into Array#findIndex

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,4 +1,10 @@
 'use strict';
+var findIndex = require('array-findindex');
+
+// TODO Move ponyfill to separate module.
+Array.prototype.findIndex = Array.prototype.findIndex || function (callback, thisArg) {
+	return findIndex(this, callback, thisArg);
+};
 
 // WARNING: This undocumented API is subject to change.
 
@@ -10,9 +16,9 @@ module.exports = function (process) {
 	});
 
 	process.on('rejectionHandled', function (p) {
-		var index = unhandledRejections.reduce(function (result, item, idx) {
-			return (item.promise === p ? idx : result);
-		}, -1);
+		var index = unhandledRejections.findIndex(function (item) {
+			return (item.promise === p);
+		});
 
 		unhandledRejections.splice(index, 1);
 	});

--- a/api.js
+++ b/api.js
@@ -1,12 +1,16 @@
 'use strict';
-var findIndex = require('array-findindex');
-
-// TODO Move ponyfill to separate module.
-Array.prototype.findIndex = Array.prototype.findIndex || function (callback, thisArg) {
-	return findIndex(this, callback, thisArg);
-};
 
 // WARNING: This undocumented API is subject to change.
+
+// TODO Move ponyfill to separate module.
+var findIndex;
+if (Array.prototype.findIndex) {
+	findIndex = function (arr, callback, thisArg) {
+		return arr.findIndex(callback, thisArg);
+	};
+} else {
+	findIndex = require('array-findindex');
+}
 
 module.exports = function (process) {
 	var unhandledRejections = [];
@@ -16,7 +20,7 @@ module.exports = function (process) {
 	});
 
 	process.on('rejectionHandled', function (p) {
-		var index = unhandledRejections.findIndex(function (item) {
+		var index = findIndex(unhandledRejections, function (item) {
 			return (item.promise === p);
 		});
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "verbose"
   ],
   "dependencies": {
+    "array-findindex": "^0.1.0",
     "signal-exit": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The logic that finds the index of the item seemed like a good candidate for ES6's `Array.prototype.findIndex`, so I looked for a lightweight ponyfill to make the code more readable. The closest existing one I could find was `array-findindex`.