### PR TITLE
extract api.js into it's own module, and deprecate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ node_js:
   - '5'
   - '4'
   - '0.12'
+
+before_install:
+  - 'npm install -g npm@latest'
+
 after_success: npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,4 @@ node_js:
   - '5'
   - '4'
   - '0.12'
-
-before_install:
-  - 'npm install -g npm@latest'
-
 after_success: npm run coveralls

--- a/api.js
+++ b/api.js
@@ -1,33 +1,11 @@
 'use strict';
-var arrayFindIndex = require('array-find-index');
+var util = require('util');
+var currentlyUnhandled = require('currently-unhandled');
 
 // WARNING: This undocumented API is subject to change.
 
-module.exports = function (process) {
-	var unhandledRejections = [];
-
-	process.on('unhandledRejection', function (reason, p) {
-		unhandledRejections.push({reason: reason, promise: p});
-	});
-
-	process.on('rejectionHandled', function (p) {
-		var index = arrayFindIndex(unhandledRejections, function (x) {
-			return x.promise === p;
-		});
-
-		unhandledRejections.splice(index, 1);
-	});
-
-	function currentlyUnhandled() {
-		return unhandledRejections.map(function (entry) {
-			return {
-				reason: entry.reason,
-				promise: entry.promise
-			};
-		});
-	}
-
+module.exports = util.deprecate(function (process) {
 	return {
-		currentlyUnhandled: currentlyUnhandled
+		currentlyUnhandled: currentlyUnhandled(process)
 	};
-};
+}, 'loudRejection/api is deprecated. Use currently-unhandled instead.');

--- a/api.js
+++ b/api.js
@@ -8,4 +8,4 @@ module.exports = util.deprecate(function (process) {
 	return {
 		currentlyUnhandled: currentlyUnhandled(process)
 	};
-}, 'loudRejection/api is deprecated. Use currently-unhandled instead.');
+}, 'loudRejection/api is deprecated. Use the currently-unhandled module instead.');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var util = require('util');
 var onExit = require('signal-exit');
-var api = require('./api');
+var currentlyUnhandled = require('currently-unhandled');
 var installed = false;
 
 function outputRejectedMessage(err) {
@@ -19,10 +19,10 @@ module.exports = function () {
 
 	installed = true;
 
-	var tracker = api(process);
+	var listUnhandled = currentlyUnhandled();
 
 	onExit(function () {
-		var unhandledRejections = tracker.currentlyUnhandled();
+		var unhandledRejections = listUnhandled();
 
 		if (unhandledRejections.length > 0) {
 			unhandledRejections.forEach(function (x) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "verbose"
   ],
   "dependencies": {
-    "array-find-index": "^1.0.0",
+    "currently-unhandled": "^0.3.0",
     "signal-exit": "^2.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "verbose"
   ],
   "dependencies": {
-    "currently-unhandled": "^0.3.0",
+    "currently-unhandled": "^0.4.0",
     "signal-exit": "^2.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "verbose"
   ],
   "dependencies": {
-    "currently-unhandled": "^0.4.0",
+    "currently-unhandled": "^0.4.1",
     "signal-exit": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
`currently-unhandled` can be browserified (though only Chrome supports the behavior right now). Unfortunately, the events are a totally different for browers and Node (names are different, arguments are different, etc).

Rather than try and shoehorn browser support into this project (which has pretty clear intent), I just forked it into a new module.